### PR TITLE
infra: stabilize CI and add deterministic verifier tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
+
+O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### 🔧 Fixed
+- Corrigidos imports incorretos em `aethel_router.py`
+- Corrigido `AethelLauncher.ps1` para apontar para diretórios corretos
+- Adicionado `conftest.py` para corrigir testes quebrados
+
+### 📝 Added
+- Adicionado README.md principal
+- Adicionado CONTRIBUTING.md
+- Adicionado LICENSE (Apache 2.0)
+- Adicionado CHANGELOG.md
+- Adicionado análise completa do projeto (`ANALISE_COMPLETA_PROJETO_2025.md`)
+
+### 📝 CI / Infra
+- 2025-11-01: Melhorias de confiabilidade do CI: adicionada mock CI (`tools/ci/ci-mock.js`) e hardening das esperas/health checks para reduzir flakiness do Playwright.
+- 2025-11-01: Adicionado verificador determinístico e helpers de física em `tools/llm-mock` com testes unitários para cobrir casos de borda.
+- 2025-11-01: Documentação de reprodução local do CI adicionada em `docs/CI_LOCAL.md` e scripts de diagnóstico em `tools/ci/`.
+
+## [0.2.0] - 2025-01-15
+
+### ✨ Added
+- **MemoryEngine**: Sistema de memória avançado com SQLite + embeddings
+- **Multi-Agent System**: 5 agentes especializados (Code, Content, QA, Infra, Critic)
+- **Desktop IDE**: AethelIDE.exe compilado (183.54 MB)
+- **Web Portal**: Next.js 14.2.5 com 10+ rotas
+- **VSCode Extension**: 12 comandos únicos implementados
+- **Unreal Plugin**: 90+ arquivos C++ fonte
+- **Visual Scripting**: Godot forks integrados
+- **Photogrammetry**: AliceVision fork
+
+### 🔧 Fixed
+- Correções críticas no backend (imports, async/sync)
+- Correções na extensão VSCode (template literals, tipos)
+- Locking SQLite no Windows
+
+### 📝 Documentation
+- Master Plan V2 completo
+- Technical Plan MVP
+- Status Final (100% pronto para execução)
+- Interface Unified Map
+- Master Roadmap 2025 (18 meses)
+- 5 Propostas Técnicas detalhadas
+- Approved Packages Checklist (58 pacotes)
+
+## [0.1.0] - 2024-12-01
+
+### ✨ Added
+- **Backend Core**: FastAPI com SQLAlchemy
+- **Frontend Core**: Next.js com Tailwind CSS
+- **Theia Fork**: 78 packages com AI integrations
+- **Basic Authentication**: JWT + bcrypt
+- **Basic Billing**: Stripe integration skeleton
+- **AI Providers**: OpenAI, Anthropic, Google, Ollama, HuggingFace
+
+### 📝 Documentation
+- Documentação inicial
+- Setup guides
+- Architecture overview
+
+## [0.0.1] - 2024-10-01
+
+### ✨ Added
+- Estrutura inicial do projeto
+- Configuração de repositório
+- Planejamento estratégico
+
+---
+
+## Tipos de Mudanças
+
+- `✨ Added` - Novas funcionalidades
+- `🔧 Fixed` - Correções de bugs
+- `🔄 Changed` - Mudanças em funcionalidades existentes
+- `🗑️ Deprecated` - Funcionalidades que serão removidas
+- `❌ Removed` - Funcionalidades removidas
+- `🔒 Security` - Correções de segurança
+- `📝 Documentation` - Mudanças na documentação
+- `⚡ Performance` - Melhorias de performance
+
+---
+
+[Unreleased]: https://github.com/aethel-ide/aethel/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/aethel-ide/aethel/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/aethel-ide/aethel/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/aethel-ide/aethel/releases/tag/v0.0.1


### PR DESCRIPTION
## CI diagnostics and next steps (auto-draft)

This is a ready-to-post comment summarizing what I reproduced, the low-risk fixes I pushed, and how to proceed with the PR CI.

Summary
-------
- I reproduced Playwright + Jest locally against the mock server and collected diagnostics.
- Implemented small, low-risk CI hardenings on branch `infra/playwright-ci-ensemble-workflow-fix`:
  - Start mock server with `MOCK_DEBUG=true` so `tools/llm-mock/verifier-debug.json` can be produced.
  - Install `tools/llm-mock` dependencies with `npm ci` when a lockfile is present (fallback to `npm install`).
  - Increased health poll robustness (longer total wait) and print `verifier-debug.json` on failure.
  - Upload `tools/llm-mock/server.err.log` artifact on every run.
- Found a malformed top-level `package-lock.json`. I moved it to `package-lock.json.broken` to avoid tooling parse errors and reduce CI flakiness.

What I ran locally
------------------
- Mock: `MOCK_DEBUG=true node tools/llm-mock/server.js` (server bound to 0.0.0.0)
- Jest (mock): `cd tools/llm-mock && npm test` (unit tests passing locally)
- Playwright: `npx playwright test --project=chromium --reporter=html` (report generated in `playwright-report/`)

Artifacts I added to the branch
-----------------------------
- `diagnostics/verifier-debug.json` â€” verifier output (weapon_present) generated locally for triage
- `diagnostics/PLAYWRIGHT_SUMMARY.txt` â€” brief local Playwright run summary
- `diagnostics/server.log` â€” tail of mock server log during local run
- `playwright-report/` â€” local HTML report

How to repro the failure locally (short)
---------------------------------------
1. Start server: `MOCK_DEBUG=true node tools/llm-mock/server.js`
2. Run Playwright: `npx playwright test --project=chromium --reporter=html`
3. Inspect `tools/llm-mock/verifier-debug.json` and `playwright-report/index.html`

What I need from the PR run
---------------------------
- Please re-run the PR CI (Actions -> the PR -> Re-run jobs). The updated workflow is already on the branch.
- If CI still fails, download the artifacts produced by that run and attach them here (server.log, server.err.log, verifier-debug artifact, playwright-report). I can triage them and propose follow-ups.

Suggested follow-ups (if CI still flakes)
---------------------------------------
1. If health waits still time out occasionally, increase `MAX_ATTEMPTS` and/or add exponential backoff.
2. Add Playwright test retries or run tests with `--retries=1` in CI to reduce flakiness.
3. Add an explicit small `tools/ci/dev-mock-health.sh` script (invoked by CI) that prints helpful debug info before failing.

Draft PR comment (copy/paste)
----------------------------
I reproduced the Playwright/Jest runs locally and pushed low-risk CI hardenings to this branch: enabled `MOCK_DEBUG`, prefer `npm ci` in `tools/llm-mock` when possible, increased health wait, and upload server.err.log. I also moved a malformed top-level `package-lock.json` to `package-lock.json.broken` to avoid JSON parse failures in tooling.

Please re-run the PR checks. If jobs still fail, download the artifacts (server.log, server.err.log, verifier-debug.json, playwright-report) and attach them here; I will triage and supply a minimal follow-up patch.

-- End of draft
