### PR TITLE
chore(visual): capture visual baseline + workflow

### DIFF
--- a/.github/workflows/visual-regression-baseline.yml
+++ b/.github/workflows/visual-regression-baseline.yml
@@ -1,0 +1,60 @@
+name: Visual Regression - Capture Baseline
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 5 * * 0' # weekly on Sunday 05:00 UTC
+
+jobs:
+  capture-baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Start dev server (background)
+        run: |
+          npm run dev &
+          sleep 5
+
+      - name: Capture baseline screenshots
+        run: |
+          node tools/ide/visual-regression/capture_baseline.js --baseUrl http://localhost:3000 --out tools/ide/visual-regression/output/baseline
+
+      - name: Upload baseline artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-baseline
+          path: tools/ide/visual-regression/output/baseline
+
+      - name: Commit baseline to branch
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin visual-baseline:visual-baseline || true
+          if git rev-parse --verify visual-baseline >/dev/null 2>&1; then
+            git checkout visual-baseline
+          else
+            git checkout -b visual-baseline
+          fi
+          mkdir -p tools/ide/visual-regression/baseline
+          cp -r tools/ide/visual-regression/output/baseline/* tools/ide/visual-regression/baseline/ || true
+          git add tools/ide/visual-regression/baseline
+          if git diff --staged --quiet; then
+            echo "No baseline changes to commit"
+          else
+            git commit -m "chore(visual-baseline): update baseline screenshots"
+            git push --set-upstream origin visual-baseline
+          fi

--- a/tools/ide/visual-regression/capture_baseline.js
+++ b/tools/ide/visual-regression/capture_baseline.js
@@ -1,0 +1,41 @@
+// Simple visual regression baseline capture using Playwright.
+// Usage: node capture_baseline.js --baseUrl http://localhost:3000 --out ./output/baseline
+
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('@playwright/test');
+
+function readJSON(p) { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+
+async function run() {
+  const args = require('minimist')(process.argv.slice(2));
+  const baseUrl = args.baseUrl || process.env.BASE_URL || 'http://localhost:3000';
+  const outDir = path.resolve(args.out || path.join(__dirname, 'output', 'baseline'));
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+  const pagesFile = path.join(__dirname, '..', 'ui-audit', 'pages.json');
+  const pages = fs.existsSync(pagesFile) ? readJSON(pagesFile) : [{name:'home', path:'/'}];
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await context.newPage();
+
+  for (const p of pages) {
+    const url = new URL(p.path, baseUrl).toString();
+    console.log('Capturing', url);
+    try {
+      await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+    } catch (err) {
+      console.warn('  failed to load', url, err.message);
+      continue;
+    }
+    const outPath = path.join(outDir, `${p.name}.png`);
+    await page.screenshot({ path: outPath, fullPage: true });
+    console.log('  wrote', outPath);
+  }
+
+  await browser.close();
+  console.log('Baseline capture complete');
+}
+
+run().catch(err=>{ console.error(err); process.exit(1); });


### PR DESCRIPTION
Adds a Playwright-based capture script that collects baseline screenshots for core pages and a workflow that runs weekly or on-demand. The workflow uploads artifacts and commits baseline screenshots to the isual-baseline branch for review.

Run locally: node tools/ide/visual-regression/capture_baseline.js --baseUrl http://localhost:3000 --out ./tools/ide/visual-regression/output/baseline