### PR TITLE
feat(ai-ide): add branding bar, default layout, status bar and refine…

### DIFF
--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -144,17 +144,15 @@ jobs:
           fi
 
       - name: Run Playwright tests
-        run: |
-          # Run Playwright tests and generate an HTML report in playwright-report
-          # Guard invocation: only run Playwright when a config file is present to
-          # avoid passing --project when projects are not defined (causes errors).
-          if [ -f playwright.config.ts ] || [ -f playwright.config.js ]; then
-            echo "Found playwright config - running tests with --config"
-            # Prefer --config to selectively run projects defined in the repo
-            npx playwright test --config=playwright.config.ts --retries=1 --reporter=html || true
-          else
-            echo "No playwright config found; skipping Playwright tests"
-          fi
+        run: >-
+          bash -eo pipefail -c '
+            if [ -f playwright.config.ts ] || [ -f playwright.config.js ]; then
+              echo "Found playwright config - running tests with --config"
+              npx playwright test --config=playwright.config.ts --retries=1 --reporter=html || true
+            else
+              echo "No playwright config found; skipping Playwright tests"
+            fi
+          '
 
       - name: Archive Playwright report (zip)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         # lightweight forks), skip the ai-ide tsc step instead of failing the
         # whole job. This keeps CI green for other checks while preserving the
         # intended tsc invocation when the tree is present.
+        shell: bash
         run: |
           if [ -f "cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/tsconfig.json" ]; then
             (cd cloud-ide-desktop/aethel_theia_fork && npx -y tsc --noEmit -p packages/ai-ide/tsconfig.json)
@@ -95,16 +96,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browsers
-        # Cache Playwright browsers to speed up CI (stored in ~/.cache/ms-playwright)
-        - name: Cache Playwright browsers
-          uses: actions/cache@v4
-          with:
-            path: ~/.cache/ms-playwright
-            key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
-        - name: Install Playwright browsers
-          run: npm run playwright:install
+      - name: Install Playwright browsers
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+        run: npm run playwright:install
 
       - name: Start dev mock backend + proxy shim
         run: |

--- a/.github/workflows/visual-regression-compare.yml
+++ b/.github/workflows/visual-regression-compare.yml
@@ -92,12 +92,10 @@ jobs:
           path: tools/ide/visual-regression/output/diffs
 
       - name: Check report and create issue if regressions
-        if: ${{ secrets.GH_PAT != '' }}
+        if: always()
         uses: actions/github-script@v6
         with:
-          # Prefer a repo secret PAT for creating issues (secrets.GH_PAT).
-          # When running from forks/sealed contexts the secret will be empty and this step will be skipped.
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const reportPath = 'tools/ide/visual-regression/output/diffs/compare-report.json';
@@ -106,7 +104,12 @@ jobs:
             const total = report.totalDiff || 0;
             if (total > 500) {
               const body = `Visual regression detected: total differing pixels = ${total}. See artifacts attached to the workflow run.`;
-              await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title: 'Visual regression detected', body });
+              try {
+                await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title: 'Visual regression detected', body });
+                core.info('Opened regression issue for visibility.');
+              } catch (error) {
+                core.warning(`Unable to create issue: ${error.message}`);
+              }
               core.setFailed('Visual regression threshold exceeded');
             } else {
               core.info(`Total diff pixels: ${total}`);

--- a/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/branding/ai-ide-branding-contribution.ts
+++ b/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/branding/ai-ide-branding-contribution.ts
@@ -1,0 +1,18 @@
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import type { Widget } from '@theia/core/lib/browser/widgets/widget';
+import { AiIdeBrandingWidget } from './ai-ide-branding-widget';
+
+@injectable()
+export class AiIdeBrandingContribution implements FrontendApplicationContribution {
+    constructor(
+        @inject(AiIdeBrandingWidget) private readonly widget: AiIdeBrandingWidget,
+    ) {}
+
+    async onStart(app: FrontendApplication): Promise<void> {
+        // Ensure the branding bar is attached once the shell is ready.
+        if (!this.widget.isAttached) {
+            app.shell.addWidget(this.widget as unknown as Widget, { area: 'top' });
+        }
+    }
+}

--- a/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/branding/ai-ide-branding-widget.tsx
+++ b/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/branding/ai-ide-branding-widget.tsx
@@ -1,0 +1,164 @@
+import * as React from '@theia/core/shared/react';
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { AIConfigurationSelectionService } from '../ai-configuration/ai-configuration-service';
+import { ProviderConfigurationWidget } from '../ai-configuration/provider-configuration-widget';
+import { AIAgentConfigurationWidget } from '../ai-configuration/agent-configuration-widget';
+import { AIToolsConfigurationWidget } from '../ai-configuration/tools-configuration-widget';
+import { AITokenUsageConfigurationWidget } from '../ai-configuration/token-usage-configuration-widget';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { AIHistoryView } from '@theia/ai-history/lib/browser/ai-history-widget';
+
+type ShellArea = 'main' | 'left' | 'right' | 'bottom' | 'top';
+
+interface QuickActionConfig {
+    id: string;
+    label: string;
+    description: string;
+    codicon: string;
+    widgetId: string;
+    area: ShellArea;
+    onAfterOpen?: () => void;
+}
+
+@injectable()
+export class AiIdeBrandingWidget extends ReactWidget {
+    static readonly ID = 'ai-ide-branding-widget';
+
+    protected quickActions: QuickActionConfig[] = [];
+
+    constructor(
+        @inject(ApplicationShell) private readonly shell: ApplicationShell,
+        @inject(WidgetManager) private readonly widgetManager: WidgetManager,
+        @inject(AIConfigurationSelectionService) private readonly configurationSelection: AIConfigurationSelectionService,
+    ) {
+        super();
+        this.id = AiIdeBrandingWidget.ID;
+        this.addClass('ai-ide-branding-widget');
+        this.node.setAttribute('role', 'banner');
+    }
+
+    @postConstruct()
+    protected init(): void {
+        this.quickActions = [
+            {
+                id: 'providers',
+                label: 'Provedores',
+                description: 'Configurar provedores LLM e credenciais',
+                codicon: 'cloud',
+                widgetId: ProviderConfigurationWidget.ID,
+                area: 'left'
+            },
+            {
+                id: 'agents',
+                label: 'Agentes',
+                description: 'Gerenciar agentes orquestradores',
+                codicon: 'organization',
+                widgetId: AIAgentConfigurationWidget.ID,
+                area: 'left'
+            },
+            {
+                id: 'tools',
+                label: 'Ferramentas',
+                description: 'Habilitar e revisar ferramentas disponíveis',
+                codicon: 'tools',
+                widgetId: AIToolsConfigurationWidget.ID,
+                area: 'left'
+            },
+            {
+                id: 'usage',
+                label: 'Uso de Tokens',
+                description: 'Monitorar consumo e billing',
+                codicon: 'graph-line',
+                widgetId: AITokenUsageConfigurationWidget.ID,
+                area: 'bottom'
+            },
+            {
+                id: 'chat',
+                label: 'Chat',
+                description: 'Voltar para a conversa ativa',
+                codicon: 'comment-discussion',
+                widgetId: ChatViewWidget.ID,
+                area: 'main'
+            },
+            {
+                id: 'history',
+                label: 'Histórico',
+                description: 'Explorar execuções e auditoria',
+                codicon: 'history',
+                widgetId: AIHistoryView.ID,
+                area: 'right'
+            },
+        ];
+    }
+
+    protected render(): React.ReactNode {
+        return (
+            <div className='ai-ide-branding-bar'>
+                <div className='ai-ide-branding-identity'>
+                    <div className='ai-ide-logo-mark' aria-hidden='true'>
+                        <svg width='32' height='32' viewBox='0 0 32 32' role='img'>
+                            <defs>
+                                <linearGradient id='ai-ide-logo-gradient' x1='0%' y1='0%' x2='100%' y2='100%'>
+                                    <stop offset='0%' stopColor='#6366f1'/>
+                                    <stop offset='100%' stopColor='#22d3ee'/>
+                                </linearGradient>
+                            </defs>
+                            <rect x='2' y='2' width='28' height='28' rx='8' fill='url(#ai-ide-logo-gradient)'/>
+                            <path d='M11.5 22L16 10l4.5 12h-2.6l-.9-2.4h-3.6l-.9 2.4h-2.6Zm4.5-4.4L14.8 14l-1.2 3.6h2.4Z' fill='#0f172a'/>
+                        </svg>
+                    </div>
+                    <div className='ai-ide-branding-text'>
+                        <span className='ai-ide-branding-name'>Aethel IDE</span>
+                        <span className='ai-ide-branding-tagline'>Orquestre provedores, agentes e ferramentas de IA com confiança</span>
+                    </div>
+                </div>
+                <div className='ai-ide-branding-actions'>
+                    {this.quickActions.map(action => this.renderAction(action))}
+                </div>
+            </div>
+        );
+    }
+
+    protected renderAction(action: QuickActionConfig): React.ReactNode {
+        const codiconClass = `codicon codicon-${action.codicon}`;
+        return (
+            <button
+                key={action.id}
+                className='ai-ide-branding-action'
+                title={action.description}
+                onClick={() => this.handleAction(action)}
+            >
+                <span className={codiconClass} aria-hidden='true'/>
+                <span>{action.label}</span>
+            </button>
+        );
+    }
+
+    protected async handleAction(action: QuickActionConfig): Promise<void> {
+        await this.openWidget(action.widgetId, action.area);
+        if (action.widgetId === ProviderConfigurationWidget.ID) {
+            this.configurationSelection.selectConfigurationTab(ProviderConfigurationWidget.ID);
+        }
+        if (typeof action.onAfterOpen === 'function') {
+            try {
+                action.onAfterOpen();
+            } catch (error) {
+                console.warn('[ai-ide] quick action callback failure', error);
+            }
+        }
+    }
+
+    protected async openWidget(widgetId: string, area: ShellArea): Promise<void> {
+        try {
+            const widget = await this.widgetManager.getOrCreateWidget(widgetId);
+            if (!widget.isAttached) {
+                this.shell.addWidget(widget, { area });
+            }
+            await this.shell.activateWidget(widgetId);
+        } catch (error) {
+            console.error(`[ai-ide] failed to open widget ${widgetId} from branding bar`, error);
+        }
+    }
+}

--- a/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/frontend-module.ts
+++ b/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/frontend-module.ts
@@ -114,6 +114,10 @@ import { LlmProviderCommandContribution } from './llm-provider-command-contribut
 import { BillingAdminWidget } from './admin/billing-admin-widget';
 import { BillingAdminContribution } from './admin/billing-admin-contribution';
 import { BillingAdminCommandContribution } from './admin/billing-admin-command-contribution';
+import { AiIdeLayoutContribution } from './layout/ai-ide-layout-contribution';
+import { AiIdeBrandingWidget } from './branding/ai-ide-branding-widget';
+import { AiIdeBrandingContribution } from './branding/ai-ide-branding-contribution';
+import { AiIdeStatusBarContribution } from './status/ai-ide-status-bar-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: aiIdePreferenceSchema });
@@ -145,6 +149,15 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(BillingAdminCommandContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(BillingAdminCommandContribution as unknown);
     bind(FrontendApplicationContribution).toService(BillingAdminContribution as unknown);
+
+    bind(AiIdeBrandingWidget).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).to(AiIdeBrandingContribution).inSingletonScope();
+
+    bind(AiIdeLayoutContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(AiIdeLayoutContribution);
+
+    bind(AiIdeStatusBarContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(AiIdeStatusBarContribution);
 
     // ensure preference key symbol is referenced so TS doesn't report it as unused in incremental builds
     const _aiLlmPref = AI_LLM_PROVIDERS_PREF;

--- a/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/layout/ai-ide-layout-contribution.ts
+++ b/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/layout/ai-ide-layout-contribution.ts
@@ -1,0 +1,82 @@
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { ApplicationShell, FrontendApplication, FrontendApplicationContribution, WidgetManager } from '@theia/core/lib/browser';
+import type { Widget } from '@theia/core/lib/browser/widgets/widget';
+import { ProviderConfigurationWidget } from '../ai-configuration/provider-configuration-widget';
+import { AIAgentConfigurationWidget } from '../ai-configuration/agent-configuration-widget';
+import { AIToolsConfigurationWidget } from '../ai-configuration/tools-configuration-widget';
+import { AITokenUsageConfigurationWidget } from '../ai-configuration/token-usage-configuration-widget';
+import { AIHistoryView } from '@theia/ai-history/lib/browser/ai-history-widget';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+
+/**
+ * Shapes the default workbench layout so the IDE boots with a populated surface that
+ * mirrors the multi-panel workflows we discussed (configuration panes on the left,
+ * chat + inspector center, telemetry/billing on the right/bottom).
+ */
+@injectable()
+export class AiIdeLayoutContribution implements FrontendApplicationContribution {
+    protected readonly widgetIcons = new Map<string, string>([
+        [ProviderConfigurationWidget.ID, 'codicon codicon-cloud'],
+        [AIAgentConfigurationWidget.ID, 'codicon codicon-organization'],
+        [AIToolsConfigurationWidget.ID, 'codicon codicon-tools'],
+        [AITokenUsageConfigurationWidget.ID, 'codicon codicon-graph-line'],
+        [ChatViewWidget.ID, 'codicon codicon-comment-discussion'],
+        [AIHistoryView.ID, 'codicon codicon-history']
+    ]);
+
+    constructor(
+        @inject(ApplicationShell) private readonly shell: ApplicationShell,
+        @inject(WidgetManager) private readonly widgetManager: WidgetManager,
+    ) {}
+
+    async initializeLayout(_app: FrontendApplication): Promise<void> {
+        const layoutPromises = [
+            this.openWidget(ProviderConfigurationWidget.ID, 'left', { rank: 10 }),
+            this.openWidget(AIAgentConfigurationWidget.ID, 'left', { rank: 20 }),
+            this.openWidget(AIToolsConfigurationWidget.ID, 'left', { rank: 30 }),
+            this.openWidget(AITokenUsageConfigurationWidget.ID, 'bottom', { rank: 10 }),
+            this.openWidget(ChatViewWidget.ID, 'main'),
+            this.openWidget(AIHistoryView.ID, 'right', { rank: 10 }),
+        ];
+
+        await Promise.all(layoutPromises);
+
+        await this.ensureWidgetVisible(ProviderConfigurationWidget.ID);
+        this.shell.leftPanelHandler.expand(ProviderConfigurationWidget.ID);
+
+        await this.ensureWidgetVisible(AIHistoryView.ID);
+        this.shell.rightPanelHandler.expand(AIHistoryView.ID);
+
+        await this.ensureWidgetVisible(AITokenUsageConfigurationWidget.ID);
+
+        // Finish on the chat view so the primary interaction surface is selected.
+        await this.ensureWidgetVisible(ChatViewWidget.ID);
+    }
+
+    private async openWidget(widgetId: string, area: ApplicationShell.Area, options: { rank?: number } = {}): Promise<void> {
+        try {
+            const widget = await this.widgetManager.getOrCreateWidget(widgetId);
+            const iconClass = this.widgetIcons.get(widgetId);
+            if (iconClass) {
+                widget.title.iconClass = iconClass;
+            }
+            await this.attachIfNeeded(widget, area, options);
+        } catch (error) {
+            console.error(`[ai-ide] failed to open widget ${widgetId}`, error);
+        }
+    }
+
+    private async attachIfNeeded(widget: Widget, area: ApplicationShell.Area, options: { rank?: number }): Promise<void> {
+        if (!widget.isAttached) {
+            this.shell.addWidget(widget, { area, ...options });
+        }
+    }
+
+    private async ensureWidgetVisible(widgetId: string): Promise<void> {
+        try {
+            await this.shell.activateWidget(widgetId);
+        } catch (error) {
+            console.warn(`[ai-ide] failed to activate widget ${widgetId}`, error);
+        }
+    }
+}

--- a/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/status/ai-ide-status-bar-contribution.ts
+++ b/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/status/ai-ide-status-bar-contribution.ts
@@ -1,0 +1,81 @@
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application-contribution';
+import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser/status-bar/status-bar';
+import { PreferenceService } from '@theia/core';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { AIConfigurationSelectionService } from '../ai-configuration/ai-configuration-service';
+import { LlmProviderRegistry } from '../llm-provider-registry';
+import { AI_LLM_PROVIDERS_PREF } from '../../common/ai-llm-preferences';
+import type { Agent } from '@theia/ai-core/lib/common';
+
+@injectable()
+export class AiIdeStatusBarContribution implements FrontendApplicationContribution {
+    protected readonly toDispose = new DisposableCollection();
+
+    constructor(
+        @inject(StatusBar) private readonly statusBar: StatusBar,
+        @inject(LlmProviderRegistry) private readonly providerRegistry: LlmProviderRegistry,
+        @inject(AIConfigurationSelectionService) private readonly selectionService: AIConfigurationSelectionService,
+        @inject(PreferenceService) private readonly preferenceService: PreferenceService,
+    ) {}
+
+    onStart(): void {
+        this.renderProviderSummary();
+        this.renderActiveAgent();
+
+        this.toDispose.push(this.preferenceService.onPreferenceChanged(change => {
+            if (change.preferenceName === AI_LLM_PROVIDERS_PREF) {
+                this.renderProviderSummary();
+            }
+        }));
+
+        const agentEvent = this.selectionService.onDidAgentChange as unknown;
+        if (typeof agentEvent === 'function') {
+            this.toDispose.push(agentEvent((agent: Agent | undefined) => {
+                this.renderActiveAgent(agent?.name ?? agent?.id ?? undefined);
+            }));
+        }
+    }
+
+    protected renderProviderSummary(): void {
+        const providers = this.safeGetProviders();
+        const defaultProvider = this.providerRegistry.getDefaultProviderId();
+        const total = providers.length;
+        const summary = total === 0 ? 'Nenhum provedor configurado' : `${total} provedor${total > 1 ? 'es' : ''}`;
+        const tooltip = defaultProvider
+            ? `Provedor padrão: ${defaultProvider}\nClique para abrir as configurações.`
+            : 'Configure provedores LLM. Clique para abrir as configurações.';
+
+        this.statusBar.setElement('ai-ide-provider-summary', {
+            alignment: StatusBarAlignment.LEFT,
+            text: `$(cloud) ${summary}`,
+            tooltip,
+            priority: 1000,
+            command: 'aiConfiguration:open'
+        });
+    }
+
+    protected renderActiveAgent(agentName?: string): void {
+        const label = agentName || 'Agente não selecionado';
+        this.statusBar.setElement('ai-ide-active-agent', {
+            alignment: StatusBarAlignment.LEFT,
+            text: `$(person) ${label}`,
+            tooltip: 'Selecione e configure agentes de IA.',
+            priority: 950,
+            command: 'aiConfiguration:open'
+        });
+    }
+
+    protected safeGetProviders(): Array<{ id: string; name?: string }> {
+        try {
+            return this.providerRegistry.getAll();
+        } catch (error) {
+            console.warn('[ai-ide] Não foi possível recuperar provedores cadastrados', error);
+            return [];
+        }
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+}

--- a/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/style/index.css
+++ b/cloud-ide-desktop/aethel_theia_fork/packages/ai-ide/src/browser/style/index.css
@@ -1,0 +1,481 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap');
+
+:root {
+    --ai-ide-font-stack: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    --ai-ide-font-mono: 'JetBrains Mono', 'Fira Code', Consolas, 'Courier New', monospace;
+    --ai-ide-background: #0f172a;
+    --ai-ide-surface: #1e293b;
+    --ai-ide-surface-alt: #273554;
+    --ai-ide-surface-elevated: #334155;
+    --ai-ide-overlay: rgba(15, 23, 42, 0.85);
+    --ai-ide-border: rgba(99, 102, 241, 0.35);
+    --ai-ide-border-muted: rgba(148, 163, 184, 0.24);
+    --ai-ide-border-strong: rgba(94, 234, 212, 0.45);
+    --ai-ide-accent: #6366f1;
+    --ai-ide-accent-secondary: #22d3ee;
+    --ai-ide-accent-warm: #f59e0b;
+    --ai-ide-text: #f8fafc;
+    --ai-ide-text-muted: #cbd5e1;
+    --ai-ide-text-subtle: #94a3b8;
+    --ai-ide-shadow-sm: 0 6px 24px rgba(15, 23, 42, 0.35);
+    --ai-ide-shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.45);
+    --ai-ide-radius-sm: 8px;
+    --ai-ide-radius-md: 12px;
+    --ai-ide-radius-lg: 18px;
+    --ai-ide-transition: 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body,
+.theia-app-shell {
+    font-family: var(--ai-ide-font-stack);
+    background: radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.25), transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(34, 211, 238, 0.15), transparent 50%),
+        linear-gradient(140deg, #070b14 0%, #0b1222 40%, #111c33 100%);
+    color: var(--ai-ide-text);
+    letter-spacing: 0.01em;
+}
+
+.theia-main-content-panel {
+    background-color: transparent;
+}
+
+.theia-side-panel,
+.theia-bottom-panel {
+    background: var(--ai-ide-surface);
+    border-color: var(--ai-ide-border-muted) !important;
+    box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+}
+
+.theia-bottom-panel {
+    border-top: 1px solid var(--ai-ide-border-muted) !important;
+}
+
+.p-TabBar {
+    --theia-ui-font-size: 11px;
+}
+
+.p-TabBar-tab {
+    background: rgba(51, 65, 85, 0.45);
+    border: 1px solid transparent;
+    border-radius: 6px 6px 0 0;
+    margin-right: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.045em;
+    font-size: 11px;
+    color: var(--ai-ide-text-subtle);
+    transition: border-color var(--ai-ide-transition), background var(--ai-ide-transition);
+}
+
+.p-TabBar-tab:hover {
+    color: var(--ai-ide-text);
+    border-color: rgba(148, 163, 184, 0.35);
+}
+
+.p-TabBar-tab.p-mod-current {
+    border-color: var(--ai-ide-accent-secondary);
+    background: rgba(99, 102, 241, 0.18);
+    color: var(--ai-ide-text);
+    box-shadow: 0 4px 12px rgba(99, 102, 241, 0.25);
+}
+
+.p-TabBar-tab.p-mod-current::before {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--ai-ide-accent), var(--ai-ide-accent-secondary));
+}
+
+.p-TabBar-tabIcon.codicon {
+    font-size: 16px;
+    margin-right: 6px;
+    opacity: 0.85;
+}
+
+.theia-panel-title {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--ai-ide-text-subtle);
+    font-size: 11px;
+}
+
+/* Branding bar */
+
+#theia-top-panel {
+    background: rgba(15, 23, 42, 0.82);
+    border-bottom: 1px solid rgba(99, 102, 241, 0.25);
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(18px);
+}
+
+.ai-ide-branding-widget {
+    width: 100%;
+}
+
+.ai-ide-branding-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 12px 24px;
+}
+
+.ai-ide-branding-identity {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.ai-ide-logo-mark {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    box-shadow: var(--ai-ide-shadow-sm);
+    overflow: hidden;
+}
+
+.ai-ide-branding-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.ai-ide-branding-name {
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.ai-ide-branding-tagline {
+    font-size: 12px;
+    color: var(--ai-ide-text-subtle);
+    letter-spacing: 0.04em;
+}
+
+.ai-ide-branding-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.ai-ide-branding-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(99, 102, 241, 0.18);
+    border: 1px solid rgba(99, 102, 241, 0.4);
+    border-radius: var(--ai-ide-radius-sm);
+    color: var(--ai-ide-text);
+    padding: 8px 14px;
+    font-size: 12px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    transition: transform var(--ai-ide-transition), box-shadow var(--ai-ide-transition), border-color var(--ai-ide-transition);
+}
+
+.ai-ide-branding-action .codicon {
+    font-size: 16px;
+}
+
+.ai-ide-branding-action:hover {
+    transform: translateY(-1px);
+    border-color: rgba(34, 211, 238, 0.6);
+    box-shadow: 0 10px 30px rgba(34, 211, 238, 0.25);
+}
+
+.ai-ide-branding-action:focus-visible {
+    outline: 2px solid var(--ai-ide-accent-secondary);
+    outline-offset: 2px;
+}
+
+/* Status bar */
+
+#theia-statusBar {
+    background: rgba(10, 16, 28, 0.92);
+    border-top: 1px solid rgba(99, 102, 241, 0.18);
+    box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.35);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+}
+
+.theia-status-bar-item {
+    color: var(--ai-ide-text-subtle);
+}
+
+.theia-status-bar-item:hover {
+    color: var(--ai-ide-text);
+}
+
+.theia-status-bar-item .codicon {
+    margin-right: 4px;
+}
+
+/* Generic elements */
+
+button,
+input,
+select,
+textarea {
+    font-family: inherit;
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    background: rgba(15, 23, 42, 0.78);
+    color: var(--ai-ide-text);
+    border: 1px solid var(--ai-ide-border-muted);
+    border-radius: var(--ai-ide-radius-sm);
+    padding: 8px 10px;
+    font-size: 13px;
+    transition: border-color var(--ai-ide-transition), box-shadow var(--ai-ide-transition);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--ai-ide-accent);
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.35);
+}
+
+button {
+    cursor: pointer;
+}
+
+button:not(.ai-ide-branding-action) {
+    background: rgba(99, 102, 241, 0.16);
+    border: 1px solid rgba(99, 102, 241, 0.4);
+    border-radius: var(--ai-ide-radius-sm);
+    color: var(--ai-ide-text);
+    padding: 6px 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 11px;
+    transition: background var(--ai-ide-transition), border-color var(--ai-ide-transition);
+}
+
+button:not(.ai-ide-branding-action):hover {
+    background: rgba(99, 102, 241, 0.25);
+    border-color: rgba(34, 211, 238, 0.45);
+}
+
+label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 11px;
+    color: var(--ai-ide-text-subtle);
+    margin-bottom: 6px;
+    display: inline-block;
+}
+
+.provider-config-root {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    gap: 24px;
+    padding: 12px 18px;
+    color: var(--ai-ide-text);
+    font-size: 13px;
+}
+
+.provider-config-column {
+    background: rgba(15, 23, 42, 0.78);
+    border: 1px solid var(--ai-ide-border-muted);
+    border-radius: var(--ai-ide-radius-md);
+    padding: 18px;
+    box-shadow: var(--ai-ide-shadow-sm);
+}
+
+.provider-config-column h3 {
+    margin-top: 0;
+    margin-bottom: 16px;
+    font-size: 14px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ai-ide-text-muted);
+}
+
+.provider-config-column ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.provider-item {
+    background: rgba(39, 53, 84, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: var(--ai-ide-radius-sm);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    transition: border-color var(--ai-ide-transition), transform var(--ai-ide-transition);
+}
+
+.provider-item:hover {
+    border-color: rgba(99, 102, 241, 0.45);
+    transform: translateY(-1px);
+}
+
+.provider-item button {
+    margin-right: 8px;
+}
+
+.provider-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.provider-config-column input,
+.provider-config-column select {
+    margin-bottom: 12px;
+}
+
+.ai-tools-configuration-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 18px;
+    background: rgba(15, 23, 42, 0.78);
+    border-radius: var(--ai-ide-radius-md);
+    border: 1px solid var(--ai-ide-border-muted);
+}
+
+.ai-tools-configuration-default-section {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    border-radius: var(--ai-ide-radius-sm);
+    background: rgba(39, 53, 84, 0.6);
+    border: 1px solid rgba(99, 102, 241, 0.25);
+}
+
+.ai-tools-configuration-tools-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.ai-tools-configuration-tool-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: var(--ai-ide-radius-sm);
+    background: rgba(39, 53, 84, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.ai-tools-configuration-tool-item.custom {
+    border-color: rgba(245, 158, 11, 0.45);
+}
+
+.ai-tools-configuration-tool-name {
+    font-family: var(--ai-ide-font-mono);
+    font-size: 12px;
+    color: var(--ai-ide-text);
+}
+
+.ai-ide-chat-bubble {
+    background: rgba(39, 53, 84, 0.6);
+    border-radius: var(--ai-ide-radius-lg);
+    padding: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    margin-bottom: 14px;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.35);
+}
+
+.ai-ide-chat-bubble.user {
+    border-color: rgba(34, 211, 238, 0.55);
+    background: rgba(20, 184, 166, 0.16);
+}
+
+.ai-ide-chat-bubble.assistant {
+    border-color: rgba(99, 102, 241, 0.55);
+}
+
+.ai-ide-section-heading {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 24px 0 12px;
+    color: var(--ai-ide-text-subtle);
+}
+
+.ai-ide-section-tag {
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.6);
+    margin-bottom: 6px;
+}
+
+.ai-ide-footer-button {
+    background: rgba(99, 102, 241, 0.16);
+    border: 1px solid rgba(99, 102, 241, 0.4);
+    border-radius: var(--ai-ide-radius-sm);
+    padding: 6px 16px;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.ai-ide-footer-button.primary {
+    background: linear-gradient(120deg, rgba(99, 102, 241, 0.85), rgba(34, 211, 238, 0.75));
+    border: none;
+    color: #0b1120;
+    font-weight: 600;
+}
+
+.theia-TreeNode,
+.theia-TreeNodeLabel {
+    font-size: 12px;
+    letter-spacing: 0.02em;
+}
+
+.theia-TreeNode:hover {
+    background: rgba(99, 102, 241, 0.18) !important;
+}
+
+/* Scrollbar styling */
+
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+::-webkit-scrollbar-track {
+    background: rgba(15, 23, 42, 0.6);
+}
+
+::-webkit-scrollbar-thumb {
+    background: rgba(99, 102, 241, 0.45);
+    border-radius: 20px;
+    border: 2px solid rgba(15, 23, 42, 0.6);
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: rgba(34, 211, 238, 0.55);
+}
+
+::selection {
+    background: rgba(99, 102, 241, 0.35);
+    color: #f8fafc;
+}


### PR DESCRIPTION
…d theme

- Register AiIdeBrandingWidget in frontend-module.ts to display identity banner with quick actions
- Add AiIdeLayoutContribution to bootstrap left/right/bottom panes and assign codicons on startup
- Introduce AiIdeStatusBarContribution for live provider/agent readouts in the status bar
- Expand style/index.css with cohesive tokens, branding bar, chat bubbles, provider config UI
- Clean GitHub workflows: fix YAML linting in ci.yml, ci-playwright.yml, visual-regression-compare.yml

Tests: npm run test:ai-ide, npm run test:e2e (5/5 passed)